### PR TITLE
Remove nacks field from slow link event

### DIFF
--- a/src/backend/janus.rs
+++ b/src/backend/janus.rs
@@ -378,7 +378,6 @@ pub(crate) struct SlowLinkEvent {
     sender: i64,
     opaque_id: String,
     uplink: bool,
-    nacks: i32,
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
https://sentry.io/organizations/ng-org/issues/1708524373/?project=1541639