### PR TITLE
order rtc list by created_at asc

### DIFF
--- a/src/db/rtc.rs
+++ b/src/db/rtc.rs
@@ -116,7 +116,7 @@ impl ListQuery {
             q = q.limit(limit);
         }
 
-        q.order_by(rtc::created_at.desc()).get_results(conn)
+        q.order_by(rtc::created_at.asc()).get_results(conn)
     }
 }
 


### PR DESCRIPTION
created_at desc order changes if new rtcs were created and right now
we sometimes erroneously create multiple rtcs

sorting by created_at asc will always return the oldest rtc first
so without any changes to frontend logic we can amend the problem of
stream splitting across multiple rtcs